### PR TITLE
null許容が気になったので削除

### DIFF
--- a/src/features/Index/index.tsx
+++ b/src/features/Index/index.tsx
@@ -6,7 +6,7 @@ import {
   SelectedPrefectureData,
   getPopulationData,
   getPrefectures,
-  YearlyPopulationData
+  YearlyPopulationData,
 } from '@/functions/getPeopleData';
 import Layout from '@/layout/layout';
 
@@ -68,7 +68,6 @@ const IndexPage = (): JSX.Element => {
       // 選択されたカテゴリの切り替え
       const selectedData = data?.[selectedPopulationCategory]?.data;
 
-
       selectedData?.forEach(({ year, value }) => {
         if (!mergedData[year]) {
           mergedData[year] = { year: year, value: 0 };
@@ -109,11 +108,9 @@ const IndexPage = (): JSX.Element => {
           data={generateChartData()}
           margin={{ top: 10, right: 10, left: 80, bottom: 80 }}
         >
-          {Object.entries(selectedPrefecturesData).map(([prefCode, { name, data }], index) =>
-            data ? (
-              <Line type="monotone" dataKey={name} stroke={COLOR_LIST[index % COLOR_LIST.length]} key={prefCode} />
-            ) : null,
-          )}
+          {Object.entries(selectedPrefecturesData).map(([prefCode, { name }], index) => (
+            <Line type="monotone" dataKey={name} stroke={COLOR_LIST[index % COLOR_LIST.length]} key={prefCode} />
+          ))}
           <CartesianGrid stroke="#ccc" />
           <XAxis dataKey="year">
             <Label value="年" offset={-20} position="insideBottom" />

--- a/src/functions/getPeopleData.ts
+++ b/src/functions/getPeopleData.ts
@@ -14,7 +14,7 @@ export const getPopulationData = async (prefCode: number) => {
       },
     },
   );
-  
+
   return response.data.result;
 };
 
@@ -35,9 +35,8 @@ export interface Prefecture {
 
 interface PopulationDatum {
   label: string;
-  data: Array<{year: number, value: number}>;
+  data: Array<{ year: number; value: number }>;
 }
-
 
 export interface PopulationData {
   boundaryYear: number;
@@ -46,7 +45,7 @@ export interface PopulationData {
 
 export interface PrefectureData {
   name: string;
-  data: PopulationDatum[] | null;
+  data: PopulationDatum[];
 }
 
 export interface SelectedPrefectureData {


### PR DESCRIPTION
- 一個前のPRを見て、
```
    {Object.entries(selectedPrefecturesData).map(([prefCode, { name, data }], index) =>
            data ? (
              <Line type="monotone" dataKey={name} stroke={COLOR_LIST[index % COLOR_LIST.length]} key={prefCode} />
            ) : null,
          )}
```
でnullがあるのが気になったので少し修正した

- 他の変更はformatterの違いによるもの